### PR TITLE
[cassandra] Move to Cassaforte 2.0

### DIFF
--- a/modules/cassandra/project.clj
+++ b/modules/cassandra/project.clj
@@ -1,13 +1,9 @@
 ;; Copyright © 2014 JUXT LTD.
 
-(defproject juxt.modular/cassandra "0.3.0"
+(defproject juxt.modular/cassandra "0.4.0"
   :description "A modular extension that provides support for Cassandra (via cassaforte)"
   :url "https://github.com/juxt/modular/tree/master/modules/cassandra"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[clojurewerkz/cassaforte "1.3.0-beta9"
-                  :exclusions [[com.datastax.cassandra/cassandra-driver-core]]]
-                 [com.datastax.cassandra/cassandra-driver-core "1.0.5"
-                  :exclusions [[org.slf4j/slf4j-log4j12]
-                               [log4j/log4j]]]
+  :dependencies [[clojurewerkz/cassaforte "2.0.0-beta1"]
                  [prismatic/schema "0.2.1"]])

--- a/modules/cassandra/src/modular/cassandra.clj
+++ b/modules/cassandra/src/modular/cassandra.clj
@@ -16,11 +16,11 @@
     this))
 
 (def ClusterSchema
-  {:contact-points [s/Str]
+  {:hosts [s/Str]
    :port s/Int})
 
 (def ClusterDefaults
-  {:contact-points ["127.0.0.1"]
+  {:hosts ["127.0.0.1"]
    :port 9042})
 
 (defn new-cluster [opts]


### PR DESCRIPTION
`:contact-points` changes to `:hosts`, Java driver dependency is now `2.0.x`. The rest of API changes do not affect this project.
