### PR TITLE
Keep bools and reject odd number of args

### DIFF
--- a/modules/maker/src/modular/maker.clj
+++ b/modules/maker/src/modular/maker.clj
@@ -20,6 +20,7 @@ path in the config where the value should be found.
 
 See modular.maker-tests/make-args-test for examples."
   [cfg & args]
+  (assert (= 0 (mod (count args) 2)))
   (apply concat
          (for [[k dv]
                (partition 2 args)]
@@ -28,12 +29,13 @@ See modular.maker-tests/make-args-test for examples."
                                  (associative? k)
                                  (let [path (second (first (seq k)))]
                                    (cond (keyword? path) [path]
-                                         (vector? path) path))))]
+                                         (vector? path) path)))
+                           dv)]
              (cond
-              (and (= dv :modular.maker/required) (nil? v))
+              (and (= dv v :modular.maker/required))
               (throw (ex-info "Configuration value required but couldn't be found" {:key-or-mapping k}))
-              (keyword? k) [k (or v dv)]
-              (associative? k) [(ffirst (seq k)) (or v dv)])))))
+              (keyword? k) [k v]
+              (associative? k) [(ffirst (seq k)) v])))))
 
 (defn make
   "Call the constructor with default keyword arguments, each of which is

--- a/modules/maker/test/modular/maker_tests.clj
+++ b/modules/maker/test/modular/maker_tests.clj
@@ -14,9 +14,14 @@
     (is (= '(:a 2) (make-args {:a 2} :a nil))))
   (testing "Nil selects config"
     (is (= '(:a 2) (make-args {:a 2} :a :required))))
+  (testing "Preservation of Boolean values"
+    (is (= '(:a false :b true) (make-args {:a false :b true} :a nil :b nil))))
   (testing "Exception thrown on required"
     (is (thrown? clojure.lang.ExceptionInfo
                  (make-args {} :a :modular.maker/required))))
+  (testing "Exception thrown on odd number of args"
+    (is (thrown? java.lang.AssertionError
+                 (make-args {} :a))))
   (testing "Mapping with a keyword"
     (is (= '(:a 2) (make-args {:b 2} {:a :b} 1))))
   (testing "Mapping with a vector path"


### PR DESCRIPTION
- A simple assert makes sure that the number of kv's passed to make-args
  is always even.
- Boolean values, specifically falses, were getting lost due to the use
  of a bare `or`. By switching to using `dv` in the `get-in` instead,
  the code is both simpler and more correct.
