### PR TITLE
Minor fixes to modular bidi

### DIFF
--- a/modules/bidi/project.clj
+++ b/modules/bidi/project.clj
@@ -8,7 +8,6 @@
   :dependencies [[com.stuartsierra/component "0.2.1"]
                  [bidi "1.18.0"]
                  [juxt.modular/ring "0.5.2"]
-                 [prismatic/schema "0.3.3"]
-                 [prismatic/plumbing "0.3.5"]]
+                 [prismatic/schema "0.3.3"]]
   :profiles {:dev
              {:dependencies [[ring-mock "0.1.5"]]}})

--- a/modules/bidi/project.clj
+++ b/modules/bidi/project.clj
@@ -6,7 +6,7 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[com.stuartsierra/component "0.2.1"]
-                 [bidi "1.18.0-SNAPSHOT"]
+                 [bidi "1.18.0"]
                  [juxt.modular/ring "0.5.2"]
                  [prismatic/schema "0.3.3"]
                  [prismatic/plumbing "0.3.5"]]

--- a/modules/bidi/src/modular/bidi.clj
+++ b/modules/bidi/src/modular/bidi.clj
@@ -7,8 +7,7 @@
    [com.stuartsierra.component :as component :refer (Lifecycle)]
    [bidi.bidi :as bidi :refer (match-route resolve-handler RouteProvider)]
    [bidi.ring :refer (resources-maybe make-handler redirect)]
-   [clojure.tools.logging :refer :all]
-   [plumbing.core :refer (?>)]))
+   [clojure.tools.logging :refer :all]))
 
 ;; TODO Support bidi route compilation
 (defn as-request-handler

--- a/modules/bidi/src/modular/bidi.clj
+++ b/modules/bidi/src/modular/bidi.clj
@@ -6,8 +6,7 @@
    [modular.ring :refer (WebRequestHandler)]
    [com.stuartsierra.component :as component :refer (Lifecycle)]
    [bidi.bidi :as bidi :refer (match-route resolve-handler RouteProvider)]
-   [bidi.ring :refer (resources-maybe make-handler redirect)]
-   [clojure.tools.logging :refer :all]))
+   [bidi.ring :refer (resources-maybe make-handler redirect)]))
 
 ;; TODO Support bidi route compilation
 (defn as-request-handler

--- a/modules/bidi/src/modular/bidi.clj
+++ b/modules/bidi/src/modular/bidi.clj
@@ -13,7 +13,7 @@
 (defn as-request-handler
   "Take a WebService component and return a Ring handler."
   [service not-found-handler]
-  (assert (or (satisfies? RouteProvider service)))
+  (assert (satisfies? RouteProvider service))
   (some-fn
    (make-handler
     (cond


### PR DESCRIPTION
The goal here was really jus to get rid of `prismatic/plumbling` which was an unused dep.  External dependencies should be limited in projects like this because collisions among transitive dependencies is so annoying to deal with.

Test output on `master` (after changing to bidi 1.18.0 because the snapshot isn't on clojars):

```
Ran 1 tests containing 10 assertions.
8 failures, 0 errors.
Tests failed.
```

Results are the same in this branch.

Let me know in the event you want all of these commits but want me to squash them ,instead of doing that yourself on a merge into master.
