### PR TITLE
Fix stop method of http-kit component

### DIFF
--- a/modules/http-kit/src/modular/http_kit.clj
+++ b/modules/http-kit/src/modular/http_kit.clj
@@ -22,9 +22,9 @@
                       {:this this}))))
 
   (stop [this]
-    (when-let [server (:server this)]
-      (server)
-      (dissoc this :server))))
+    (if-let [server (:server this)]
+      (server))
+    (dissoc this :server)))
 
 (defn new-webserver [& {:as opts}]
   (let [{:keys [port]} (->> (merge {:port default-port} opts)


### PR DESCRIPTION
The method returned nil if the component was not started.