### PR TITLE
store the correct boss and worker groups in the component so Netty can

### DIFF
--- a/modules/netty/src/modular/netty.clj
+++ b/modules/netty/src/modular/netty.clj
@@ -49,8 +49,8 @@
 
            (assoc this
              :channel (.bind b port)
-             :boss-group (NioEventLoopGroup.)
-             :worker-group (NioEventLoopGroup.))))))
+             :boss-group boss-group
+             :worker-group worker-group)))))
 
    (stop [this]
      (let [fut (:channel this)]


### PR DESCRIPTION
be properly shut down
